### PR TITLE
eth.public-rpc.com is deprecated [chore]: eth.public-rpc.com -> eth.llamarpc.com

### DIFF
--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 ## Endpoint
-The default endpoint is https://eth.public-rpc.com, and you can also set your preferred endpoint.
+The default endpoint is https://eth.llamarpc.com, and you can also set your preferred endpoint.
 You can find free endpoints from [ChainList](https://chainlist.org/chain/1).
 To set your endpoint, run with a `--endpoint` option.
 ```sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use tokio::sync::Mutex;
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Json-RPC URL
-    #[arg(short, long, default_value = "https://eth.public-rpc.com")]
+    #[arg(short, long, default_value = "https://eth.llamarpc.com")]
     endpoint: String,
 }
 


### PR DESCRIPTION
## Motivation

Since eth.public-rpc.com has been discontinued, we will use DefiLlama. It may be necessary to consider other reliable endpoints as well.
reference: https://eth.public-rpc.com/
>Freemium endpoint
Public access has been deprecated. Sign in to start using the endpoint for free.

## Solution

Reaching more reliable and accurate endpoints